### PR TITLE
Update mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,9 @@ defmodule SortedSet.Mixfile do
      elixir: "~> 1.0",
      description: "SortedSet implementation for Elixir",
      licenses: ["MIT"],
-     deps: deps]
+     deps: deps,
+     package: package
+     ]
   end
 
   def application do
@@ -19,6 +21,15 @@ defmodule SortedSet.Mixfile do
     [
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.7", only: :dev}
+    ]
+  end
+  
+  defp package do
+    [
+     files: ["lib", "mix.exs", "README.md", "LICENSE"],
+     contributors: ["Seneca Systems"],
+     licenses: ["MIT"],
+     links: %{"GitHub" => "https://github.com/SenecaSystems/sorted_set"}
     ]
   end
 end


### PR DESCRIPTION
Adding `package` information to `mix.exs`. A proper link on `hex.pm` to `github` repo would help spur contributions.
